### PR TITLE
flush progress print

### DIFF
--- a/corrscope/corrscope.py
+++ b/corrscope/corrscope.py
@@ -150,7 +150,7 @@ class Arguments:
     outputs: List[outputs_.IOutputConfig]
 
     on_begin: BeginFunc = lambda begin_time, end_time: None
-    progress: ProgressFunc = print
+    progress: ProgressFunc = lambda p: print(p,flush=True)
     is_aborted: IsAborted = lambda: False
     on_end: Callable[[], None] = lambda: None
 


### PR DESCRIPTION
I found the reason why I couldn't reliably get the progress in my wrapper script. I tested this patch locally and it seems to fix the issue.